### PR TITLE
Subscribe to list different from app.config list

### DIFF
--- a/MailChimp.Net.Api/IMailChimpApiService.cs
+++ b/MailChimp.Net.Api/IMailChimpApiService.cs
@@ -16,6 +16,8 @@ namespace MailChimp.Net.Api
 
         ServiceResponse Subscribe(string email, List<Grouping> groupings, Dictionary<string, string> field, bool enableDoubleOptIn);
 
+        ServiceResponse Subscribe(string email, string listId, List<Grouping> groupings, Dictionary<string, string> fields, bool enableDoubleOptIn);
+
         ServiceResponse Unsubscribe(string email);
     }
 }

--- a/MailChimp.Net.Api/MailChimpApiService.cs
+++ b/MailChimp.Net.Api/MailChimpApiService.cs
@@ -67,7 +67,7 @@ namespace MailChimp.Net.Api
         }
 
 
-        private ServiceResponse SubscribeWithMergeVars(string email, dynamic mergeVars, bool enableDoubleOptIn)
+        private ServiceResponse SubscribeWithMergeVars(string email, string listId, dynamic mergeVars, bool enableDoubleOptIn)
         {
             ServiceResponse serviceResponse = new ServiceResponse();
             var urlTemplate = String.Format("{0}{1}/subscribe.json/", MailChimpServiceConfiguration.Settings.ServiceUrl,
@@ -76,7 +76,7 @@ namespace MailChimp.Net.Api
             var subscriber = new Subscriber();
             subscriber.DoubleOptIn = enableDoubleOptIn;
             subscriber.ApiKey = _apiKey;
-            subscriber.ListId = MailChimpServiceConfiguration.Settings.SubscriberListId;
+            subscriber.ListId = listId;
             var emailObject = new Email { EmailValue = email };
             subscriber.Email = emailObject;
             subscriber.UpdateExisting = true;
@@ -111,16 +111,28 @@ namespace MailChimp.Net.Api
 
         public ServiceResponse Subscribe(string email, List<Grouping> groupings, Dictionary<string, string> fields, bool enableDoubleOptIn)
         {
+            return Subscribe(email,
+                             MailChimpServiceConfiguration.Settings.SubscriberListId,
+                             groupings,
+                             fields,
+                             enableDoubleOptIn);
+        }
+
+        public ServiceResponse Subscribe(string email, string listId, List<Grouping> groupings, Dictionary<string, string> fields, bool enableDoubleOptIn)
+        {
             dynamic mergeVars = new Dictionary<string, Object>();
             mergeVars.Add("groupings", groupings);
 
-            foreach (var nameValue in fields)
+            if (fields != null)
             {
-                //Dynamically adding properties to an ExpandoObject
-                //http://stackoverflow.com/questions/4938397/dynamically-adding-properties-to-an-expandoobject
-                mergeVars.Add(nameValue.Key, nameValue.Value);
+                foreach (var nameValue in fields)
+                {
+                    //Dynamically adding properties to an ExpandoObject
+                    //http://stackoverflow.com/questions/4938397/dynamically-adding-properties-to-an-expandoobject
+                    mergeVars.Add(nameValue.Key, nameValue.Value);
+                }
             }
-            var response = this.SubscribeWithMergeVars(String.Format(email), mergeVars, enableDoubleOptIn);
+            var response = this.SubscribeWithMergeVars(String.Format(email), listId, mergeVars, enableDoubleOptIn);
 
             return response;
         }

--- a/MailChimp.Net.Tests/SectionTests.cs
+++ b/MailChimp.Net.Tests/SectionTests.cs
@@ -67,6 +67,42 @@ namespace MailChimp.Net.Tests
             }
         }
 
+        [TestCase("spyros_bluecoupon{0}@gmail.com", 5)]
+        public void TestSubscribeWithGroupingsAndMergeVarsAndCustomListId(string emailPattern, int numberOfEmails)
+        {
+            IMailChimpApiService mailChimpApiService = new MailChimpApiService(MailChimpServiceConfiguration.Settings.ApiKey);
+            const string customListId = "71d6c2a0f0";
+            for (int i = 0; i < numberOfEmails; i++)
+            {
+                var subscribeSources = new Grouping {Name = "Subscribe Source"};
+                subscribeSources.Groups.Add("Site");
+
+                var couponsGained = new Grouping {Name = "Coupons Gained"};
+                couponsGained.Groups.Add("Coupon1");
+
+                var interests = new Grouping {Name = "Interests"};
+                interests.Groups.Add("Extreme Games");
+
+
+                var fields = new Dictionary<string, string>
+                    {
+                        {"GENDER", "Male"},
+                        {"DATEBORN", DateTime.Now.ToString(CultureInfo.InvariantCulture)},
+                        {"CITY", "Athens"},
+                        {"COUNTRY", "Greece"}
+                    };
+
+                var response = mailChimpApiService.Subscribe(String.Format(emailPattern, i), 
+                    customListId,
+                    new List<Grouping>() { subscribeSources, couponsGained, interests }, 
+                    fields, 
+                    false);
+
+                Console.WriteLine(response.ResponseJson);
+                Assert.AreEqual(true, response.IsSuccesful);
+            }
+        }
+
 
         [TestCase("spyros{0}@gmail.com", 5)]
         public void TestUnSubscribe(string emailPattern, int numberOfEmails)


### PR DESCRIPTION
Add the ability to subscribe to a list different from the list ID in the
app.config file

Hi, thanks for the library you wrote, I have been using it and has been of great help.

I have added a small piece of functionality. Basically the change allows the developer to specify a list ID other than the list ID in the configuration. I have left the existing functionality in place and all the tests pass (after updating the app.config for my MailChimp setup).

Thanks
Pieter
